### PR TITLE
do not turn filename.xwd into filename.png.png

### DIFF
--- a/xwd.py
+++ b/xwd.py
@@ -273,7 +273,7 @@ def main(argv=None):
         except AttributeError:
             out = "xwd2png_out.png"
         else:
-            out = re.sub(r"(\..*|)$", ".png", inp.name)
+            out = re.sub(r"(\..*|)$", ".png", inp.name, 1)
             if out == inp.name:
                 # avoid overwriting input,
                 # if, for some reason,

--- a/xwd.py
+++ b/xwd.py
@@ -8,6 +8,7 @@ import json
 import re
 import struct
 import sys
+import io
 
 # :python3:buffer: we need to get a binary stream in both
 # Python 2 and Python 3.
@@ -287,7 +288,10 @@ def main(argv=None):
     import png
 
     apng = png.from_array(xwd, "RGB;8")
-    apng.save(out)
+    if isinstance(out, io.BufferedWriter):
+        apng.write(out)
+    else:
+        apng.save(out)
 
 
 def dprint(o, indent=0):


### PR DESCRIPTION
If the input file has an extension, both .ext and $ match the regular expression. Both get replaced by .png, resulting in filename.png.png